### PR TITLE
Add support for country_select v9. Fixes #1381

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    formtastic (4.0.0)
+    formtastic (5.0.0)
       actionpack (>= 6.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ You can use your new input with `:as => :date_picker`.
 
 There are none other than Rails itself, but...
 
-* If you want to use the `:country` input, you'll need to install the [country-select plugin](https://github.com/stefanpenner/country_select) (or any other country_select plugin with the same API). Both 1.x and 2.x are supported, but they behave differently when storing data, so please see their [upgrade notes](https://github.com/stefanpenner/country_select/blob/master/UPGRADING.md) if switching from 1.x.
+* If you want to use the `:country` input, you'll need to install the [country-select plugin](https://github.com/countries/country_select) (or any other country_select plugin with the same API).
 * There are a bunch of development dependencies if you plan to contribute to Formtastic
 
 

--- a/lib/formtastic/inputs/country_input.rb
+++ b/lib/formtastic/inputs/country_input.rb
@@ -5,12 +5,9 @@ module Formtastic
     # Rails doesn't come with a `country_select` helper by default any more, so you'll need to do
     # one of the following:
     #
-    # * install the [country_select](https://github.com/stefanpenner/country_select) gem
+    # * install the [country_select](https://github.com/countries/country_select) gem
     # * install any other country_select plugin that behaves in a similar way
     # * roll your own `country_select` helper with the same args and options as the Rails one
-    #
-    # Formtastic supports both 1.x and 2.x of stefanpenner/country_select, but if you're upgrading
-    # from 1.x, they behave quite differently, so please see their [upgrade instructions](https://github.com/stefanpenner/country_select/blob/master/UPGRADING.md).
     #
     # By default, Formtastic includes a handful of English-speaking countries as "priority
     # countries", which can be set in the `priority_countries` configuration array in the
@@ -71,11 +68,17 @@ module Formtastic
       CountrySelectPluginMissing = Class.new(StandardError)
 
       def to_html
-        raise CountrySelectPluginMissing, "To use the :country input, please install a country_select plugin, like this one: https://github.com/stefanpenner/country_select" unless builder.respond_to?(:country_select)
+        raise CountrySelectPluginMissing, "To use the :country input, please install a country_select plugin, like this one: https://github.com/countries/country_select" unless builder.respond_to?(:country_select)
         input_wrapping do
           label_html <<
-          builder.country_select(method, priority_countries, input_options, input_html_options)
+          builder.country_select(method, input_options_including_priorities, input_html_options)
         end
+      end
+
+      def input_options_including_priorities
+        return input_options unless priority_countries
+
+        input_options.merge(:priority_countries => priority_countries)
       end
       
       def priority_countries

--- a/spec/inputs/country_input_spec.rb
+++ b/spec/inputs/country_input_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'country input' do
 
   describe "when country_select is not available as a helper from a plugin" do
 
-    it "should raise an error, sugesting the author installs a plugin" do
+    it "should raise an error, suggesting the author installs a plugin" do
       expect {
         semantic_form_for(@new_post) do |builder|
           concat(builder.input(:country, :as => :country))
@@ -57,7 +57,7 @@ RSpec.describe 'country input' do
       priority_countries = ["Foo", "Bah"]
       semantic_form_for(@new_post) do |builder|
         allow(builder).to receive(:country_select).and_return("<select><option>...</option></select>".html_safe)
-        expect(builder).to receive(:country_select).with(:country, priority_countries, {}, {:id => "post_country", :required => false, :autofocus => false, :readonly => false}).and_return("<select><option>...</option></select>".html_safe)
+        expect(builder).to receive(:country_select).with(:country, { :priority_countries => priority_countries }, {:id => "post_country", :required => false, :autofocus => false, :readonly => false}).and_return("<select><option>...</option></select>".html_safe)
 
         concat(builder.input(:country, :as => :country, :priority_countries => priority_countries))
       end
@@ -70,7 +70,7 @@ RSpec.describe 'country input' do
 
       semantic_form_for(@new_post) do |builder|
         allow(builder).to receive(:country_select).and_return("<select><option>...</option></select>".html_safe)
-        expect(builder).to receive(:country_select).with(:country, priority_countries, {}, {:id => "post_country", :required => false, :autofocus => false, :readonly => false}).and_return("<select><option>...</option></select>".html_safe)
+        expect(builder).to receive(:country_select).with(:country, { :priority_countries => priority_countries }, {:id => "post_country", :required => false, :autofocus => false, :readonly => false}).and_return("<select><option>...</option></select>".html_safe)
 
         concat(builder.input(:country, :as => :country))
       end
@@ -86,7 +86,7 @@ RSpec.describe 'country input' do
 
       concat(semantic_form_for(@new_post, :namespace => 'context2') do |builder|
         allow(builder).to receive(:country_select).and_return("<select><option>...</option></select>".html_safe)
-        expect(builder).to receive(:country_select).with(:country, [], {}, {:id => "context2_post_country", :required => false, :autofocus => false, :readonly => false}).and_return("<select><option>...</option></select>".html_safe)
+        expect(builder).to receive(:country_select).with(:country, { :priority_countries => [] }, {:id => "context2_post_country", :required => false, :autofocus => false, :readonly => false}).and_return("<select><option>...</option></select>".html_safe)
         concat(builder.input(:country, :priority_countries => []))
       end)
     end
@@ -112,7 +112,7 @@ RSpec.describe 'country input' do
       end
     end
 
-    describe "whent the attribute is 'country_something'" do
+    describe "when the attribute is 'country_something'" do
 
       before do
         concat(semantic_form_for(@new_post) do |builder|


### PR DESCRIPTION
The `country_select` v2 syntax was introduced in
[August 2014](https://github.com/countries/country_select/blob/19072737cc2b2a12723b2dd273263b71fd5395ed/UPGRADING.md).

Now, 10 years and 7 major versions later, the project [dropped support for v1 syntax](https://github.com/countries/country_select/pull/224) starting with v9.

This change adapts `formtastic` to the new method signature, removes all claims that it supports v1 syntax,
and updates the URLs to the new home under a new maintainer.